### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkMetamorphosisImageRegistrationMethodv4.h
+++ b/include/itkMetamorphosisImageRegistrationMethodv4.h
@@ -47,6 +47,8 @@ class ConstantImageFilter:
 public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ConstantImageFilter);
+
   /** Standard class type alias. */
   using Self = ConstantImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -84,8 +86,6 @@ protected:
   }
 
 private:
-  ConstantImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);  //purposely not implemented
 
   OutputPixelType m_Constant;
 };
@@ -104,6 +104,8 @@ class MetamorphosisImageRegistrationMethodv4:
 public TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage, TMovingImage, TimeVaryingVelocityFieldSemiLagrangianTransform<double, TFixedImage::ImageDimension> >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MetamorphosisImageRegistrationMethodv4);
+
   /** Standard class type alias. */
   using Self = MetamorphosisImageRegistrationMethodv4;
   using Superclass = TimeVaryingVelocityFieldImageRegistrationMethodv4<TFixedImage, TMovingImage, TimeVaryingVelocityFieldSemiLagrangianTransform<double, TFixedImage::ImageDimension> >;
@@ -228,8 +230,6 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
-  MetamorphosisImageRegistrationMethodv4(const Self&);  // Intentionally not implemened
-  void operator=(const Self&);    //Intentionally not implemented
 
   double m_Scale;
   double m_RegistrationSmoothness;

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h
@@ -41,6 +41,8 @@ class TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter :
   public TimeVaryingVelocityFieldIntegrationImageFilter<TTimeVaryingVelocityField, TDisplacementField>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter);
+
   using Self = TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter;
   using Superclass = TimeVaryingVelocityFieldIntegrationImageFilter
     <TTimeVaryingVelocityField, TDisplacementField>;
@@ -111,8 +113,6 @@ protected:
   DisplacementFieldExtrapolatorPointer      m_DisplacementFieldExtrapolator;
  
 private:
-  TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter( const Self & ) ITK_DELETE_FUNCTION;
-  void operator=( const Self & ) ITK_DELETE_FUNCTION;
 
   VelocityFieldInterpolatorPointer          m_VelocityFieldInterpolator;
   VelocityFieldExtrapolatorPointer          m_VelocityFieldExtrapolator;

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h
@@ -36,6 +36,8 @@ class TimeVaryingVelocityFieldSemiLagrangianTransform :
   public TimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(TimeVaryingVelocityFieldSemiLagrangianTransform);
+
   /** Standard class type alias. */
   using Self = TimeVaryingVelocityFieldSemiLagrangianTransform;
   using Superclass = TimeVaryingVelocityFieldTransform<TParametersValueType, NDimensions>;
@@ -87,8 +89,7 @@ protected:
   ~TimeVaryingVelocityFieldSemiLagrangianTransform() override = default;
 
 private:
-  TimeVaryingVelocityFieldSemiLagrangianTransform( const Self& ) ITK_DELETE_FUNCTION;
-  void operator=( const Self& ) ITK_DELETE_FUNCTION;
+
   bool m_UseInverse;
 };
 

--- a/include/itkWrapExtrapolateImageFunction.h
+++ b/include/itkWrapExtrapolateImageFunction.h
@@ -40,6 +40,8 @@ class WrapExtrapolateImageFunction:
   public ExtrapolateImageFunction< TInputImage, TCoordRep >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(WrapExtrapolateImageFunction);
+
   /** Standard class type alias. */
   using Self = WrapExtrapolateImageFunction;
   using Superclass = ExtrapolateImageFunction< TInputImage, TCoordRep >;
@@ -163,8 +165,6 @@ protected:
   }
 
 private:
-  WrapExtrapolateImageFunction(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
 
   InterpolatorPointerType m_Interpolator;
 };


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the the toolkit when disallowing the copy constructor and the assign
operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/itk-disallow-copy-and-assign/648