### PR TITLE
STYLE: Pefer = default to explicitly trivial implementations.

### DIFF
--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h
@@ -101,7 +101,7 @@ public:
 
 protected:
   TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter();
-  ~TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter();
+  ~TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter() override = default;
 
   void PrintSelf( std::ostream & os, Indent indent ) const override;
   void BeforeThreadedGenerateData() override;

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.hxx
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.hxx
@@ -61,13 +61,6 @@ TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter
 }
 
 template<typename TTimeVaryingVelocityField, typename TDisplacementField>
-TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter
-  <TTimeVaryingVelocityField, TDisplacementField>
-::~TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter()
-{
-}
-
-template<typename TTimeVaryingVelocityField, typename TDisplacementField>
 void
 TimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter
   <TTimeVaryingVelocityField, TDisplacementField>

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h
@@ -84,7 +84,7 @@ public:
 
 protected:
   TimeVaryingVelocityFieldSemiLagrangianTransform();
-  virtual ~TimeVaryingVelocityFieldSemiLagrangianTransform(){};
+  ~TimeVaryingVelocityFieldSemiLagrangianTransform() override = default;
 
 private:
   TimeVaryingVelocityFieldSemiLagrangianTransform( const Self& ) ITK_DELETE_FUNCTION;


### PR DESCRIPTION
This check replaces default bodies of special member functions with
= default;. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of = default more clearly expreses the
intent for the special member functions.