### PR TITLE
BUG: Fix `README` Azure CI badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 ITKNDReg
 ========
 
-.. image::https://dev.azure.com/InsightSoftwareConsortium/ITKModules/_apis/build/status/InsightSoftwareConsortium.ITKNDReg?branchName=master
+.. image:: https://dev.azure.com/InsightSoftwareConsortium/ITKModules/_apis/build/status/InsightSoftwareConsortium.ITKNDReg?branchName=master
     :target: https://dev.azure.com/InsightSoftwareConsortium/ITKModules/_build?definitionId=15
     :alt: Build status
 


### PR DESCRIPTION
Fix `README` file Azure CI badge: a whitespace between the badge `image`
command and the URL was inadvertently removed in 55d9fe5.