### PR TITLE
COMP: Use C++11 override directly.

### DIFF
--- a/include/itkWrapExtrapolateImageFunction.h
+++ b/include/itkWrapExtrapolateImageFunction.h
@@ -84,7 +84,7 @@ public:
    * specified position
    */
   OutputType EvaluateAtContinuousIndex(
-    const ContinuousIndexType & index) const ITK_OVERRIDE
+    const ContinuousIndexType & index) const override
   {
 
     ContinuousIndexType nindex;


### PR DESCRIPTION
Use C++11 override directly.

Left behind in commit cb34dc6.