### PR TITLE
STYLE: Pefer = default to explicitly trivial implementations.

### DIFF
--- a/include/itkMetamorphosisImageRegistrationMethodv4.h
+++ b/include/itkMetamorphosisImageRegistrationMethodv4.h
@@ -69,8 +69,8 @@ public:
 
 
 protected:
-  ConstantImageFilter(){}
-  ~ConstantImageFilter(){}
+  ConstantImageFilter() = default;
+  ~ConstantImageFilter() override = default;
 
   /** Does the real work. */
   void DynamicThreadedGenerateData(const typename OutputImageType::RegionType& outputRegionForThread) override


### PR DESCRIPTION
This check replaces default bodies of special member functions with
= default;. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of = default more clearly expreses the
intent for the special member functions.

Left behind in commit 7d47862.