### PR TITLE
ENH: Clean `itk::WrapExtrapolateImageFunction` Python wrapping

### DIFF
--- a/wrapping/itkWrapExtrapolateImageFunction.wrap
+++ b/wrapping/itkWrapExtrapolateImageFunction.wrap
@@ -1,12 +1,3 @@
-# We should remove this after this class is wrapped in ITK
-itk_wrap_class("itk::ExtrapolateImageFunction" POINTER)
-  foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_SCALAR})
-      itk_wrap_template("${ITKM_I${t}${d}}${ITKM_D}" "${ITKT_I${t}${d}},${ITKT_D}")
-    endforeach()
-  endforeach()
-itk_end_wrap_class()
-
 itk_wrap_class("itk::WrapExtrapolateImageFunction" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_SCALAR})


### PR DESCRIPTION
Clean `itk::WrapExtrapolateImageFunction` Python wrapping: the parent
class `itk::ExtrapolateImageFunction` was wrapped in ITK in [PR
610](https://github.com/InsightSoftwareConsortium/ITK/pull/610).