### PR TITLE
STYLE: Prefer = default to explicitly trivial implementations

### DIFF
--- a/include/itkMetamorphosisImageRegistrationMethodv4.h
+++ b/include/itkMetamorphosisImageRegistrationMethodv4.h
@@ -215,7 +215,7 @@ public:
 
 protected:
   MetamorphosisImageRegistrationMethodv4();
-  ~MetamorphosisImageRegistrationMethodv4(){};
+  ~MetamorphosisImageRegistrationMethodv4() override = default;
   TimeVaryingImagePointer ApplyKernel(TimeVaryingImagePointer kernel, TimeVaryingImagePointer image);
   TimeVaryingFieldPointer ApplyKernel(TimeVaryingImagePointer kernel, TimeVaryingFieldPointer image);
   double CalculateNorm(TimeVaryingImagePointer image);


### PR DESCRIPTION
This check replaces default bodies of special member functions with
`= default;`. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of `= default` more clearly expresses the
intent for the special member functions.

Left behind in commits 7d47862 and 9160b83.