### PR TITLE
STYLE: Prefer using `https` instead of `http` in copyright notice

### DIFF
--- a/include/itkMetamorphosisImageRegistrationMethodv4.h
+++ b/include/itkMetamorphosisImageRegistrationMethodv4.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkMetamorphosisImageRegistrationMethodv4.hxx
+++ b/include/itkMetamorphosisImageRegistrationMethodv4.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.hxx
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.hxx
+++ b/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkWrapExtrapolateImageFunction.h
+++ b/include/itkWrapExtrapolateImageFunction.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkMetamorphosisImageRegistrationMethodv4Test.cxx
+++ b/test/itkMetamorphosisImageRegistrationMethodv4Test.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilterTest.cxx
+++ b/test/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilterTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkTimeVaryingVelocityFieldSemiLagrangianTransformTest.cxx
+++ b/test/itkTimeVaryingVelocityFieldSemiLagrangianTransformTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkWrapExtrapolateImageFunctionTest.cxx
+++ b/test/itkWrapExtrapolateImageFunctionTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Prefer using `https` instead of `http` in copyright notice license link.

Changed in https://github.com/InsightSoftwareConsortium/ITK/pull/3428

Fixes:
```
/home/runner/work/ITKNDReg/ITKNDReg/include/itkMetamorphosisImageRegistrationMethodv4.h:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/include/itkMetamorphosisImageRegistrationMethodv4.hxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.h:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/include/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilter.hxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.h:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/include/itkTimeVaryingVelocityFieldSemiLagrangianTransform.hxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/include/itkWrapExtrapolateImageFunction.h:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/test/itkMetamorphosisImageRegistrationMethodv4Test.cxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/test/itkTimeVaryingVelocityFieldSemiLagrangianIntegrationImageFilterTest.cxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/test/itkTimeVaryingVelocityFieldSemiLagrangianTransformTest.cxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
/home/runner/work/ITKNDReg/ITKNDReg/test/itkWrapExtrapolateImageFunctionTest.cxx:9:
 error: Header mismatch:
 ://www.apache.org/licenses/LICENSE-2.0.txt (s://www.apache.org/licenses/LICENSE-2.0.txt) :
 Utilities/KWStyle/ITKHeader.h
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKNDReg/actions/runs/13094587832/job/36535317220?pr=27#step:14:60