### PR TITLE
COMP: Bump to minimum CMake 3.16.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(NDReg)
 
 if(NOT ITK_SOURCE_DIR)


### PR DESCRIPTION
Bump to minimum CMake 3.16.3: use same `cmake_minimum_required` values as ITK.

Bumped in ITK in commit
InsightSoftwareConsortium/ITK@b01b325

Fixes:
```
-- cmake_minimum_required of 3.10.2 is not enough.
CMake Warning at D:/a/ITKNDReg/ITK/CMake/ITKModuleExternal.cmake:15 (message):
-- This is needed to allow proper setting of CMAKE_MSVC_RUNTIME_LIBRARY.
-- Do not be surprised if you run into link errors of the style:
  LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_Static' doesn't match value 'MDd_Dynamic' in module.obj
  cmake_minimum_required must be at least 3.16.3
Call Stack (most recent call first):
  CMakeLists.txt:7 (include)
```

raised for example in:
https://open.cdash.org/builds/10184907/configure